### PR TITLE
Deploy without bundle and updated Procfile and package scripts

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,0 @@
-web: webpack -p
-web: npm run server-dev

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "react-dev": "webpack -d --watch",
     "server-dev": "nodemon server/index.js",
-    "heroku-postbuild": "webpack -p --config ./webpack.config.js --progress"
+    "start": "node server/index.js",
+    "postinstall": "webpack -p --config ./webpack.config.js --progress"
   },
   "author": "Beth Johnson",
   "license": "ISC",


### PR DESCRIPTION
I think these changes will allow Heroku to build and then deploy without us pushing the bundle. 